### PR TITLE
Add package command 

### DIFF
--- a/bin/cfd
+++ b/bin/cfd
@@ -117,21 +117,22 @@ cfd_validate() {
 
 #
 # Package a stack for deployment
-# cfd_package <template> <output-template-file> <s3-bucket> <extra-options?>
+# cfd_package <template> <output-template> <s3-bucket> <s3-prefix?>
 #
 
 cfd_package() {
   test -z $1 && abort "template required"
-  test -z $3 && abort "output template file required"
-  test -z $2 && abort "s3-bucket required"
+  test -z $2 && abort "output template file required"
+  test -z $3 && abort "s3-bucket required"
 
   log package $@
 
   local template=$1
   local output_template=$2
   local s3_bucket=$3
-  shift 3
-  local extra_options=$@
+  local s3_prefix=$4
+  # shift 3
+  # local extra_options=$@
 
   log package "extra_options: ${extra_options}"
 
@@ -141,8 +142,8 @@ cfd_package() {
       --template-file "$template" \
       --output-template-file "$output_template" \
       --s3-bucket "$s3_bucket" \
-      $([[ -n $extra_options ]] && echo "$extra_options" || echo "") \
       2>&1)
+      # $([[ -n $extra_options ]] && echo "$extra_options" || echo "") \
 
   if [ "$?" -eq 0 ]; then
     log package "successful"

--- a/bin/cfd
+++ b/bin/cfd
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="0.0.2"
+VERSION="0.0.1"
 
 #
 # Log <type> <msg>
@@ -25,11 +25,11 @@ display_help() {
 
   Commands:
 
-    cfd validate <template>                 Validate a template
-    cfd package <template> <output-template-file> <s3-bucket> <extra-options?> Package a template for deployment
-    cfd plan <stack> <template> <params?>   Plan changes for a stack
-    cfd apply <stack> <template> <params?>  Apply changes to a stack
-    cfd tail <stack>                        Tail latest stack events
+    cfd validate <template>                                               Validate a template
+    cfd package <template> <output-template> <s3-bucket> <extra-options?> Package a template for deployment
+    cfd plan <stack> <template> <params?>                                 Plan changes for a stack
+    cfd apply <stack> <template> <params?>                                Apply changes to a stack
+    cfd tail <stack>                                                      Tail latest stack events
 
   Options:
 
@@ -128,7 +128,7 @@ cfd_package() {
   log package $@
 
   local template=$1
-  local output_template_file=$2
+  local output_template=$2
   local s3_bucket=$3
   shift 3
   local extra_options=$@
@@ -139,7 +139,7 @@ cfd_package() {
 
   result=$(aws cloudformation package \
       --template-file "$template" \
-      --output-template-file "$output_template_file" \
+      --output-template-file "$output_template" \
       --s3-bucket "$s3_bucket" \
       $([[ -n $extra_options ]] && echo "$extra_options" || echo "") \
       2>&1)

--- a/bin/cfd
+++ b/bin/cfd
@@ -26,7 +26,7 @@ display_help() {
   Commands:
 
     cfd validate <template>                                               Validate a template
-    cfd package <template> <output-template> <s3-bucket> <extra-options?> Package a template for deployment
+    cfd package <template> <output-template> <s3-bucket> <s3-prefix?> Package a template for deployment
     cfd plan <stack> <template> <params?>                                 Plan changes for a stack
     cfd apply <stack> <template> <params?>                                Apply changes to a stack
     cfd tail <stack>                                                      Tail latest stack events
@@ -134,7 +134,7 @@ cfd_package() {
   # shift 3
   # local extra_options=$@
 
-  log package "extra_options: ${extra_options}"
+  #log package "extra_options: ${extra_options}"
 
   log package "Packaging template '$template' to '$s3_bucket'"
 
@@ -142,6 +142,7 @@ cfd_package() {
       --template-file "$template" \
       --output-template-file "$output_template" \
       --s3-bucket "$s3_bucket" \
+      $([[ -n $s3_prefix ]] && echo "--s3-prefix $s3_prefix" || echo "") \
       2>&1)
       # $([[ -n $extra_options ]] && echo "$extra_options" || echo "") \
 

--- a/bin/cfd
+++ b/bin/cfd
@@ -26,6 +26,7 @@ display_help() {
   Commands:
 
     cfd validate <template>                 Validate a template
+    cfd package <template> <output-template-file> <s3-bucket> <extra-options?> Package a template for deployment
     cfd plan <stack> <template> <params?>   Plan changes for a stack
     cfd apply <stack> <template> <params?>  Apply changes to a stack
     cfd tail <stack>                        Tail latest stack events
@@ -39,6 +40,7 @@ display_help() {
   Aliases:
 
     v   validate
+    k   package
     p   plan
     a   apply
     t   tail
@@ -108,6 +110,43 @@ cfd_validate() {
 
   if [ "$?" -eq 0 ]; then
     log validate "successful"
+  else
+    abort "$result"
+  fi
+}
+
+#
+# Package a stack for deployment
+# cfd_package <template> <output-template-file> <s3-bucket> <extra-options?>
+#
+
+cfd_package() {
+  test -z $1 && abort "template required"
+  test -z $3 && abort "output template file required"
+  test -z $2 && abort "s3-bucket required"
+
+  log package $@
+
+  local template=$1
+  local output_template_file=$2
+  local s3_bucket=$3
+  shift 3
+  local extra_options=$@
+
+  log package "extra_options: ${extra_options}"
+
+  log package "Packaging template '$template' to '$s3_bucket'"
+
+  result=$(aws cloudformation package \
+      --template-file "$template" \
+      --output-template-file "$output_template_file" \
+      --s3-bucket "$s3_bucket" \
+      $([[ -n $extra_options ]] && echo "$extra_options" || echo "") \
+      2>&1)
+
+  if [ "$?" -eq 0 ]; then
+    log package "successful"
+    log package "result: $result"
   else
     abort "$result"
   fi
@@ -260,6 +299,7 @@ else
       -h|--help|help) display_help; exit ;;
       -i|--ignore-env) USE_CFVARS=false ;;
       v|validate) cfd_validate $2; exit ;;
+      k|package) shift; cfd_package $@; exit ;;
       p|plan) shift; cfd_plan $@; exit ;;
       a|apply) shift; cfd_apply $@; exit ;;
       t|tail) cfd_tail $2; exit ;;

--- a/bin/cfd
+++ b/bin/cfd
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="0.0.1"
+VERSION="0.0.2"
 
 #
 # Log <type> <msg>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cfd",
   "description": "Wrapper for CloudFormation deploys using the aws-cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Miles Goodings <miles.goodings@gmail.com>",
   "homepage": "https://github.com/mgoodings/cfd",
   "bugs": "https://github.com/mgoodings/cfd/issues",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cfd",
   "description": "Wrapper for CloudFormation deploys using the aws-cli",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "author": "Miles Goodings <miles.goodings@gmail.com>",
   "homepage": "https://github.com/mgoodings/cfd",
   "bugs": "https://github.com/mgoodings/cfd/issues",


### PR DESCRIPTION
fixes #1 
 
First pass at adding a package command. 

takes `template`, `output-template` and `s3-bucket` as required parameters, and `s3-prefix` as an optional parameter

```bash
cfd package my-template.yml output-template.yml my-s3-bucket some-prefix 
```