### PR TITLE
Fix CFVAR param parsing to handle vars with '=' in them

### DIFF
--- a/bin/cfd
+++ b/bin/cfd
@@ -99,7 +99,7 @@ _get_stack_params() {
 
   if $USE_CFVARS; then
     # Match CFVAR_<Parameter> environment variable names and print as list of <Parameter>=<Value> <Parameter>=<Value>
-    params+=(`env | awk -v ORS=" " -F= '{if($1 ~ /^CFVAR_/) {gsub("^CFVAR_", "", $1); print $1 "=" $2}}'`)
+params+=(`env | awk -v ORS=" " -v OFS="=" -F= '{if($1 ~ /^CFVAR_/) {gsub("^CFVAR_", "", $1)}}1'`)
   fi
 
   echo "${params[*]}"


### PR DESCRIPTION
cfd currently does not play nice with CFVAR variables with an equal sign in them (e.g. SumoLogic collector urls) 

This fixes that by tweaking the awk processor to print out all the 'fields' even if they are empty

We might need to revisit how this is handled in the future, but for now this should suffice