### PR TITLE
Fix handling of CFVAR params with an '=' in them

### DIFF
--- a/bin/cfd
+++ b/bin/cfd
@@ -99,7 +99,7 @@ _get_stack_params() {
 
   if $USE_CFVARS; then
     # Match CFVAR_<Parameter> environment variable names and print as list of <Parameter>=<Value> <Parameter>=<Value>
-params+=(`env | awk -v ORS=" " -v OFS="=" -F= '{if($1 ~ /^CFVAR_/) {gsub("^CFVAR_", "", $1)}}1'`)
+    params+=(`env | grep CFVAR | awk -v ORS=" " -v OFS="=" -F= '{if($1 ~ /^CFVAR_/) {gsub("^CFVAR_", "", $1)}}1' | cut -d1`)
   fi
 
   echo "${params[*]}"

--- a/bin/cfd
+++ b/bin/cfd
@@ -99,7 +99,7 @@ _get_stack_params() {
 
   if $USE_CFVARS; then
     # Match CFVAR_<Parameter> environment variable names and print as list of <Parameter>=<Value> <Parameter>=<Value>
-    params+=(`env | awk -v ORS=" " -v OFS="=" -F= '{if($1 ~ /^CFVAR_/) {n = index($0, "="); $2 = substr($0, n+1); NF=2; gsub("^CFVAR_", "", $1)}}1'`)
+    params+=(`env | awk -v ORS=" " -v OFS="=" -F= '{if($1 ~ /^CFVAR_/) {n = index($0, "="); $2 = substr($0, n+1); NF=2; gsub("^CFVAR_", "", $1); print $1,$2}}'`)
   fi
 
   echo "${params[*]}"

--- a/bin/cfd
+++ b/bin/cfd
@@ -99,7 +99,7 @@ _get_stack_params() {
 
   if $USE_CFVARS; then
     # Match CFVAR_<Parameter> environment variable names and print as list of <Parameter>=<Value> <Parameter>=<Value>
-    params+=(`env | awk -v ORS=" " -F= '{if($1 ~ /^CFVAR_/) {gsub("^CFVAR_", "", $1); print $1 "=" $2}}'`)
+params+=(`env | awk -v ORS=" " -v OFS="=" -F= '{if($1 ~ /^CFVAR_/) {gsub("^CFVAR_", "", $1)}}1'`)
   fi
 
   echo "${params[*]}"

--- a/bin/cfd
+++ b/bin/cfd
@@ -99,7 +99,7 @@ _get_stack_params() {
 
   if $USE_CFVARS; then
     # Match CFVAR_<Parameter> environment variable names and print as list of <Parameter>=<Value> <Parameter>=<Value>
-    params+=(`env | grep CFVAR | awk -v ORS=" " -v OFS="=" -F= '{if($1 ~ /^CFVAR_/) {gsub("^CFVAR_", "", $1)}}1' | cut -d1`)
+    params+=(`env | grep CFVAR | awk -v ORS=" " -v OFS="=" -F= '{if($1 ~ /^CFVAR_/) {gsub("^CFVAR_", "", $1)}}1'`)
   fi
 
   echo "${params[*]}"


### PR DESCRIPTION
The current version of `cfd` doesn't parse CFVAR values containing equal signs correctly. 

This change fixes that so that CFVARS vars are still processed, but any containing '=' are left as they should be.  