### PR TITLE
Prevent interpolation of CloudFormation parameters

### DIFF
--- a/bin/cfd
+++ b/bin/cfd
@@ -113,7 +113,8 @@ _get_stack_params() {
     params+=("`env | awk -v ORS=" " -F= '{if($1 ~ /^CFD_VAR_/) {n = index($0, "="); $2 = substr($0, n+1); NF=2; gsub("^CFD_VAR_", "", $1); print "\\"" $1 "=" $2 "\\""}}'`")
   fi
 
-  echo "${params[*]}"
+  # Escape $ to avoid interpolation
+  echo "${params[*]}" | sed 's/\$/\\\$/g'
 }
 
 #


### PR DESCRIPTION
When cfd command takes in params.env file or environment variables with '$' characters, it interpolates and passes the value on to aws cli unexpectedly.

E.g. 
`CFD_VAR_Test=$1ABC`

`aws cloudformation deploy --stack-name test --template-file test.yml --parameter-overrides TEST=testABC --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset`

The solution is to escape '$' using `sed`.